### PR TITLE
Ensure Gutenberg block wrapper and placeholder

### DIFF
--- a/assets/css/editor.css
+++ b/assets/css/editor.css
@@ -3,6 +3,16 @@
 .editor-styles-wrapper .igl-block .game-mod-images-more {
   min-height: 50px;
 }
+.editor-styles-wrapper .igl-block .igl-placeholder {
+  min-height: 50px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px dashed #ccc;
+  background: #fafafa;
+  color: #555;
+  margin-bottom: 10px;
+}
 .editor-styles-wrapper .igl-item-preview {
   position: relative;
   aspect-ratio: 3 / 2;

--- a/assets/js/editor.js
+++ b/assets/js/editor.js
@@ -17,6 +17,7 @@
   }
 
   blocks.registerBlockType('igl/gallery', {
+    apiVersion: 2,
     title: 'Inline Gallery Lightbox',
     icon: 'format-gallery',
     category: 'media',
@@ -51,6 +52,7 @@
 
       return el(Fragment, {},
         el('div', blockProps,
+          !items.length && el('div', { className:'igl-placeholder' }, '画像や動画を追加'),
           el('div', { className:'game-mod-images', style: gridStyle },
             first.map((it, idx)=> el('div', { className:'igl-item-preview', key:'f'+idx },
               it.type==='image' ? el('img',{src:it.url, alt:it.alt||''}) : el('div', { className:'thumb', style:{backgroundImage:`url(${it.thumbnail})`, backgroundSize:'cover'} }),


### PR DESCRIPTION
## Summary
- register block with API version 2 so Gutenberg adds wrapper props
- show a placeholder when no media items and add styling for it

## Testing
- `npm test` *(fails: Could not read package.json)*
- `php -l inline-gallery-lightbox.php`


------
https://chatgpt.com/codex/tasks/task_e_68a8590ddde083238a2aedde26219f8f