### PR TITLE
Limit initial gallery display to 10 items

### DIFF
--- a/assets/js/editor.js
+++ b/assets/js/editor.js
@@ -88,7 +88,7 @@
           el(PanelBody, { title: 'レイアウト' },
             el(RangeControl, { label:'列数', value: attributes.columns, onChange:(v)=>setAttributes({columns:v}), min:1, max:8 }),
             el(RangeControl, { label:'余白(px)', value: attributes.gap, onChange:(v)=>setAttributes({gap:v}), min:0, max:40 }),
-            el(RangeControl, { label:'初期表示数', value: attributes.maxInitial, onChange:(v)=>setAttributes({maxInitial:v}), min:0, max:100 }),
+            el(RangeControl, { label:'初期表示数 (最大10)', value: attributes.maxInitial, onChange:(v)=>setAttributes({maxInitial:v}), min:0, max:10 }),
           )
         )
       );

--- a/inline-gallery-lightbox.php
+++ b/inline-gallery-lightbox.php
@@ -67,7 +67,7 @@ function igl_render_gallery_block( $attributes, $content, $block ) {
     $items      = isset($attributes['items']) ? $attributes['items'] : [];
     $columns    = max(1, intval($attributes['columns'] ?? 4));
     $gap        = max(0, intval($attributes['gap'] ?? 10));
-    $maxInitial = max(0, intval($attributes['maxInitial'] ?? 8));
+    $maxInitial = min(10, max(0, intval($attributes['maxInitial'] ?? 8)));
 
     if (empty($items)) {
         return '<div class="igl-empty">画像や動画が未設定です。</div>';


### PR DESCRIPTION
## Summary
- Prevent server rendering from showing more than 10 initial gallery items
- Cap editor slider to maximum of 10 items and clarify label

## Testing
- `php -l inline-gallery-lightbox.php`
- `node --check assets/js/editor.js`


------
https://chatgpt.com/codex/tasks/task_e_68a85e851f608323a587a824c4fb3b35