### PR TITLE
Add guard against lightbox double init

### DIFF
--- a/assets/js/frontend.js
+++ b/assets/js/frontend.js
@@ -1,5 +1,9 @@
 // Inline Gallery Lightbox - Frontend
 document.addEventListener("DOMContentLoaded", () => {
+  if (window.__IGL_INIT__ || document.querySelector(".game-mod-lightbox")) {
+    return;
+  }
+  window.__IGL_INIT__ = true;
   // ===== Lightbox scaffold =====
   const lightbox = document.createElement("div");
   lightbox.className = "game-mod-lightbox";


### PR DESCRIPTION
## Summary
- prevent lightbox from initializing twice by checking existing element or flag

## Testing
- `node --check assets/js/frontend.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a85fbf29c88323a317632b7109e37f